### PR TITLE
add: 必要なモデルを作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'bootsnap', '>= 1.4.2', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
+gem 'pry-rails', '~> 0.3.9'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     erubi (1.11.0)
@@ -86,6 +87,11 @@ GEM
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     puma (4.3.12)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -150,6 +156,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   listen (~> 3.2)
+  pry-rails (~> 0.3.9)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.6)
   spring

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -1,0 +1,5 @@
+class Food < ApplicationRecord
+  belongs_to :restaurant
+  belongs_to :order, optional: true
+  has_one :line_food
+end

--- a/app/models/line_food.rb
+++ b/app/models/line_food.rb
@@ -1,0 +1,14 @@
+class LineFood < ApplicationRecord
+  belongs_to :food
+  belongs_to :restaurant
+  belongs_to :order, optional: true
+
+  validates :count, numericality: { greater_than: 0 }
+
+  scope :active, -> { where(active: true) }
+  scope :other_restaurant, -> (picked_restaurant_id) { where.not(restaurant_id: picked_restaurant_id) }
+
+  def total_amount
+    food.price * count
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,14 @@
+class Order < ApplicationRecord
+  has_many :line_foods
+
+  validates :total_price, numericality: { greater_than: 0 }
+
+  def save_with_update_line_foods!(line_foods)
+    ActiveRecord::Base.transaction do
+      line_foods.each do |line_food|
+        line_food.update_attributes!(active: false, order: self)
+      end
+      self.save!
+    end
+  end
+end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,0 +1,8 @@
+class Restaurant < ApplicationRecord
+  has_many :foods
+  has_many :line_foods, through: :foods
+
+  validates :name, :fee, :time_required, presence: true
+  validates :name, length: { maximum: 30 }
+  validates :fee, numericality: { greater_than: 0 }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,12 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      resources :restaurants do
+        resources :foods, only: %i[index]
+      end
+      resources :line_foods, only: %i[index create]
+      put 'line_foods/replace', to: 'line_foods#replace'
+      resources  :orders, only: %i[create]
+    end
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,17 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+3.times do |n|
+  restaurant = Restaurant.new(
+    name: "testレストラン_#{n}",
+    fee: 100,
+    time_required: 10,
+  )
+
+  12.times do |m|
+    restaurant.foods.build(
+      name: "フード名_#{m}",
+      price: 500,
+      description: "フード_#{m}の説明文です。"
+    )
+  end
+
+  restaurant.save!
+end


### PR DESCRIPTION
## 概要
- 以下のモデルを作成した。
  - `Restaurant`モデル
  - `Food`モデル
  - `LineFoods`モデル
  - `Order`モデル
- 必要なルーティングを定義した。
- `rails c`を見やすくするために`pry-rails`を導入した

## 確認方法
- gemを追加した為、`bundle install`を実施する
- `bundle exec rails routes`で問題なくルーティングの情報が表示されるか確認する
- `bundle exec rails db:seed`実行後、`bundle exec rails c`でRestaurantとFoodのインスタンスが追加されているかを確認する